### PR TITLE
Return tx receipt in mint

### DIFF
--- a/erc20.js
+++ b/erc20.js
@@ -168,7 +168,7 @@ async function mint(amount, zkpPublicKey, salt, blockchainOptions, zokratesOptio
   logger.debug('Mint output: [zA, zAIndex]:', commitment, commitmentIndex.toString());
   logger.debug('MINT COMPLETE\n');
 
-  return { commitment, commitmentIndex };
+  return { commitment, commitmentIndex, txReceipt };
 }
 
 /**


### PR DESCRIPTION
Any reason tx receipt is returned for transfer and burn but not for mint?

