### PR TITLE
fix: checks for overflow on commitment value before unpack

### DIFF
--- a/setup/gm17/ft-batch-transfer.zok
+++ b/setup/gm17/ft-batch-transfer.zok
@@ -55,6 +55,9 @@ def main(field publicInputHash, private field contractAddress, private field inp
   field[256] publicInputHashBits = unpack256(publicInputHash)
   field[256] contractAddressBits = unpack256(contractAddress)
 
+  	// Check the commitment value will not overflow the 128 bits
+  	0 == if inputValue < 2**128 then 0 else 1 fi
+
 
 	// First we construct a proof that the nullifier of the input coin is correct:
 	// H(inputSalt|secretKey) = nullifier.
@@ -94,6 +97,7 @@ def main(field publicInputHash, private field contractAddress, private field inp
 	field total = 0
 	for field i in 0..20 do
 		field[256] outputCommitment = unpack2x128To256(outputCommitments[i])
+        0 == if outputValues[i] < 2**128 then 0 else 1 fi
 		field[128] outputValueBits = unpack128(outputValues[i])
 		field[256] publicKeyBits = unpack2x128To256(publicKeys[i])
 		field[256] outputSaltBits = unpack2x128To256(outputSalts[i])
@@ -104,7 +108,6 @@ def main(field publicInputHash, private field contractAddress, private field inp
 		outputCommitment == commitmentBitsCheck // valid commitment check
 
 		total = total + outputValues[i]
-		outputValueBits[0] == 0 // overflow check
 	endfor
 
     // Sum check - we don't want anyone to create money.

--- a/setup/gm17/ft-burn.zok
+++ b/setup/gm17/ft-burn.zok
@@ -38,7 +38,11 @@ import "./common/merkle-tree/sha-root.zok" as sharoot
 
 def main(field publicInputHash, private field contractAddress, private field[2] payTo, private field value, private field[2] secretKey, private field[2] salt, private field[32] path, private field order, private field[2] nullifier, private field[2] root)->():
 
-	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs. We don't need to unpack payTo, because it isn't part of a hash.
+    // Check the commitment values will not overflow the 128 bits
+
+    0 == if value < 2**128 then 0 else 1 fi
+
+    // Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs. We don't need to unpack payTo, because it isn't part of a hash.
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
 	field[256] contractAddressBits = unpack256(contractAddress)

--- a/setup/gm17/ft-mint.zok
+++ b/setup/gm17/ft-mint.zok
@@ -24,6 +24,7 @@ def main(field publicInputHash, private field contractAddress, private field val
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. The unpacked binary string is in big endian format, left-padded with 0's. (NOTE: THIS METHOD OF PADDING IS DIFFERENT FROM THE PADDING REQUIRED FOR SHA256 - i.e. unpack128() padding is very different from that produced by shaPad64To512())
 	// unpack128 unpacks a field element to 128 field elements.
 	// The coin value is only 128 bits - no one will want more money than that.
+	0 == if value < 2**128 then 0 else 1 fi //...but lets check just in case
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
 	field[256] contractAddressBits = unpack256(contractAddress)

--- a/setup/gm17/ft-transfer.zok
+++ b/setup/gm17/ft-transfer.zok
@@ -55,6 +55,14 @@ import "./common/merkle-tree/sha-root.zok" as sharoot
 
 def main(field publicInputHash, private field contractAddress, private field valueC, private field[2] secretKeyA, private field[2] saltC, private field[32] pathC, private field orderC, private field valueD, private field[2] saltD, private field[32] pathD, private field orderD, private field[2] nullifierC, private field[2] nullifierD, private field valueE, private field[2] publicKeyB, private field[2] saltE, private field[2] commitmentE, private field valueF, private field[2] saltF, private field[2] commitmentF, private field[2] root)->():
 
+	// Check the commitment values will not overflow the 128 bits
+
+	0 == if valueC < 2**128 then 0 else 1 fi
+	0 == if valueD < 2**128 then 0 else 1 fi
+	0 == if valueE < 2**128 then 0 else 1 fi
+	0 == if valueF < 2**128 then 0 else 1 fi
+
+
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs.
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
@@ -164,12 +172,6 @@ def main(field publicInputHash, private field contractAddress, private field val
 	commitmentEBits == commitmentEBitsCheck
 	commitmentFBits == commitmentFBitsCheck
 	sumIn == sumOut
-
-	// Overflow prevention:
-	valueCBits[0] == 0
-	valueDBits[0] == 0
-	valueEBits[0] == 0
-	valueFBits[0] == 0
 
 
 	// Check that the 'public inputs' hash to the publicInputHash:

--- a/setup/gm17/mimc/ft-batch-transfer.zok
+++ b/setup/gm17/mimc/ft-batch-transfer.zok
@@ -53,6 +53,10 @@ import "../common/merkle-tree/mimc-root.zok" as mimcroot
 
 def main(field publicInputHash, private field contractAddress, private field inputValue, private field[2] secretKeyA, private field[2] inputSalt, private field[32] path, private field order, private field[2] nullifier, private field[20] outputValues, private field[20][2] publicKeys, private field[20][2] outputSalts, private field[20][2] outputCommitments, private field root)->():
 
+     // Check the commitment value will not overflow the 128 bits
+
+    0 == if inputValue < 2**128 then 0 else 1 fi
+
     field[256] publicInputHashBits = unpack256(publicInputHash)
     field[256] contractAddressBits = unpack256(contractAddress)
 	// First we construct a proof that the nullifier of the input coin is correct:
@@ -96,6 +100,7 @@ def main(field publicInputHash, private field contractAddress, private field inp
 	field total = 0
 	for field i in 0..20 do
         field[256] outputCommitment = unpack2x128To256(outputCommitments[i])
+        0 == if outputValues[i] < 2**128 then 0 else 1 fi
         field[128] outputValueBits = unpack128(outputValues[i])
         field[256] publicKeyBits = unpack2x128To256(publicKeys[i])
         field[256] outputSaltBits = unpack2x128To256(outputSalts[i])

--- a/setup/gm17/mimc/ft-burn.zok
+++ b/setup/gm17/mimc/ft-burn.zok
@@ -41,6 +41,10 @@ import "../common/merkle-tree/mimc-root.zok" as mimcroot
 
 def main(field publicInputHash, private field contractAddress, private field[2] payTo, private field value, private field[2] secretKey, private field[2] salt, private field[32] path, private field order, private field[2] nullifier, private field root)->():
 
+	 // Check the commitment value will not overflow the 128 bits
+
+	 0 == if value < 2**128 then 0 else 1 fi
+
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs. We don't need to unpack payTo, because it isn't part of a hash.
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)

--- a/setup/gm17/mimc/ft-consolidation-transfer.zok
+++ b/setup/gm17/mimc/ft-consolidation-transfer.zok
@@ -68,7 +68,7 @@ endfor
 //check that each commitment is in the merkle tree
 for field i in 0..20 do
   total = total + inputValues[i]
-
+  0 == if inputValues[i] < 2**128 then 0 else 1 fi
   //commitment[i] = H(value[i]|publicKeyA|inputSalts[i])
 
   field[128] inputValueBits = unpack128(inputValues[i])
@@ -81,8 +81,6 @@ for field i in 0..20 do
   field mimcHash = pack256(shaHash)
   mimcHash = mimcroot(paths[i], order[i], mimcHash) //root calculated from inputCommitment[i]
   root == mimcHash //root check
-
-  inputValueBits[0] == 0 // overflow check
 endfor
 
 //check that values match
@@ -90,6 +88,7 @@ total == outputValue
 
 //check output commitment
 //commitment = H(value|publicKeyA|outputSalt)
+0 == if outputValue < 2**128 then 0 else 1 fi
 field[128] outputValueBits = unpack128(outputValue)
 field[256] publicKeyBits = unpack2x128To256(publicKey)
 field[256] outputSaltBits = unpack2x128To256(outputSalt)
@@ -99,7 +98,6 @@ field[256] commitmentBitsCheck = sha256of1024(preimage1024[0..256], preimage1024
 field[256] outputCommitmentBits = unpack2x128To256(outputCommitment)
 outputCommitmentBits == commitmentBitsCheck
 
-outputValueBits[0] == 0 // overflow check
 
 // Check that the 'public inputs' hash to the publicInputHash
 // publicInputHash = H(root, ...nullifiers, outputCommitment)

--- a/setup/gm17/mimc/ft-mint.zok
+++ b/setup/gm17/mimc/ft-mint.zok
@@ -23,6 +23,7 @@ def main(field publicInputHash, private field contractAddress, private field val
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. The unpacked binary string is in big endian format, left-padded with 0's. (NOTE: THIS METHOD OF PADDING IS DIFFERENT FROM THE PADDING REQUIRED FOR SHA256 - i.e. unpack128() padding is very different from that produced by shaPad64To512())
 	// unpack128 unpacks a field element to 128 field elements.
 	// The coin value is only 128 bits - no one will want more money than that.
+	0 == if value < 2**128 then 0 else 1 fi //...but lets check just in case
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
 	field[256] contractAddressBits = unpack256(contractAddress)

--- a/setup/gm17/mimc/ft-transfer.zok
+++ b/setup/gm17/mimc/ft-transfer.zok
@@ -58,6 +58,13 @@ import "../common/merkle-tree/mimc-root.zok" as mimcroot
 
 def main(field publicInputHash,  private field contractAddress, private field valueC, private field[2] secretKeyA, private field[2] saltC, private field[32] pathC, private field orderC, private field valueD, private field[2] saltD, private field[32] pathD, private field orderD, private field[2] nullifierC, private field[2] nullifierD, private field valueE, private field[2] publicKeyB, private field[2] saltE, private field[2] commitmentE, private field valueF, private field[2] saltF, private field[2] commitmentF, private field root)->():
 
+	// Check the commitment value will not overflow the 128 bits
+
+	0 == if valueC < 2**128 then 0 else 1 fi
+	0 == if valueD < 2**128 then 0 else 1 fi
+	0 == if valueE < 2**128 then 0 else 1 fi
+	0 == if valueF < 2**128 then 0 else 1 fi
+
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs.
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
@@ -159,12 +166,6 @@ def main(field publicInputHash,  private field contractAddress, private field va
 	commitmentEBits == commitmentEBitsCheck
 	commitmentFBits == commitmentFBitsCheck
 	sumIn == sumOut
-
-	// Overflow prevention:
-	valueCBits[0] == 0
-	valueDBits[0] == 0
-	valueEBits[0] == 0
-	valueFBits[0] == 0
 
 
 	// Check that the 'public inputs' hash to the publicInputHash:


### PR DESCRIPTION
### Description

Fixes possibility of a user overflowing the value field of a commitment by inputting a value such that, when truncated to 128 bits, the checks pass. Discovered by @iAmMichaelConnor.

We check for overflow before unpacking in each fungible .zok file.

i.e. If we consider an example with 4 bits instead of 256, and a finite field of order 11 (for simplicity), 8 expressed in 4 bits is 1000, but unpacked to 2 bits is 00. 
If the circuit unpacked the commitment value from 4 to 2 bits, you could input 8 (= 1000) for a true value of 0 (= 0000), creating money (00 = 00). Say the two input commitments have value 0, but the user input both with a value of 8. Transferring back to them, the value is 
8 + 8 = (00 + 00) =  16 mod 11 = 5 = 4 + 1 = (00 + 01), creating a commitment with value 1.


### Checklist

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x] I have made all necessary changes to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
