### PR TITLE
Overflow prevention in kyc zok files

### DIFF
--- a/blacklist.md
+++ b/blacklist.md
@@ -1,4 +1,4 @@
-# Blacklisting
+# Blacklist
 
 We require the ability to blacklist certain people or, more specifically, certain Ethereum addresses
 from transacting under our KYC-regulated solution

--- a/el-gamal.md
+++ b/el-gamal.md
@@ -6,9 +6,7 @@ public key (or keys). It may be enforced by requiring a user to prove in zero kn
 have correctly encrypted transaction data (specifically: the value sent, `value`; the public key of
 the sender `pkA`; the public key of the recipient, `pkB`).
 
-
 El-Gamal encryption over a Baby Jubjub elliptic curve is a snark-friendly way to do the encryption.
-
 
 ## Setup
 
@@ -24,13 +22,11 @@ The point `G` is a publicly known generator of the Baby Jubjub curve. The dot pr
 curve. A good explanation of arithmetic over this particular curve can be found
 [here](https://iden3-docs.readthedocs.io/en/latest/iden3_repos/research/publications/zkproof-standards-workshop-2/baby-jubjub/baby-jubjub.html).
 
-
 ## Encryption by a user (don't know x1, x2, x3)
 
 A regular user of this scheme must encrypt and send the commitment value (`value`), their zkp public
 key (`pkA`), and the recipient's zkp public key (`pkB`) such that only the authority can decrypt
 them.
-
 
 El-Gamal encryption works on curve points, so the values to be encrypted need to be mapped using
 scalar multiplication:

--- a/el-gamal.md
+++ b/el-gamal.md
@@ -1,64 +1,89 @@
 # Use of El-Gamal encryption
 
-Regulatory requirements may mandate that transactions can be made visible to a specific authority (the Authority). This capability can be provided by encrypting transaction data using an Authority public key (or keys). It may be enforced by requiring a user to prove in zero knowledge that they have correctly encrypted transaction data (specifically: the value sent, `value`; the public key of the sender `pkA`; the public key of the recipient, `pkB`).
+Regulatory requirements may mandate that transactions can be made visible to a specific authority
+(the Authority). This capability can be provided by encrypting transaction data using an Authority
+public key (or keys). It may be enforced by requiring a user to prove in zero knowledge that they
+have correctly encrypted transaction data (specifically: the value sent, `value`; the public key of
+the sender `pkA`; the public key of the recipient, `pkB`).
+
 
 El-Gamal encryption over a Baby Jubjub elliptic curve is a snark-friendly way to do the encryption.
 
+
 ## Setup
 
-Firstly, the Authority chooses three random non-zero integer private keys: x1, x2, x3 from the Baby Jubjub prime field Fq and computes three corresponding public keys Y1, Y2, Y3 where:
+Firstly, the Authority chooses three random non-zero integer private keys: x1, x2, x3 from the Baby
+Jubjub prime field Fq and computes three corresponding public keys Y1, Y2, Y3 where:
 
-```
+```sh
 Y = x.G
 ```
 
-The point `G` is a publicly known generator of the Baby Jubjub curve. The dot product represents [scalar multiplication](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication) over the curve. A good explanation of arithmetic over this particular curve can be found [here](https://iden3-docs.readthedocs.io/en/latest/iden3_repos/research/publications/zkproof-standards-workshop-2/baby-jubjub/baby-jubjub.html).
+The point `G` is a publicly known generator of the Baby Jubjub curve. The dot product represents
+[scalar multiplication](https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication) over the
+curve. A good explanation of arithmetic over this particular curve can be found
+[here](https://iden3-docs.readthedocs.io/en/latest/iden3_repos/research/publications/zkproof-standards-workshop-2/baby-jubjub/baby-jubjub.html).
+
 
 ## Encryption by a user (don't know x1, x2, x3)
-A regular user of this scheme must encrypt and send the commitment value (`value`), their zkp public key (`pkA`),and the recipient's zkp public key (`pkB`) such that only the authority can decrypt them.
-El-Gamal encryption works on curve points, so the values to be encrypted need to be mapped using scalar multiplication:
 
-```
+A regular user of this scheme must encrypt and send the commitment value (`value`), their zkp public
+key (`pkA`), and the recipient's zkp public key (`pkB`) such that only the authority can decrypt
+them.
+
+
+El-Gamal encryption works on curve points, so the values to be encrypted need to be mapped using
+scalar multiplication:
+
+```sh
 M1 = value.G
 M2 = pkA.G
 M3 = pkB.G
 ```
 
-(Note: reversing this mapping requires a brute-forcing of the discrete logarithm. This requires us to restrict the possible values for the inputs. This is not hard to do but, additionally, we can potentially use this fact to make decryption computationally intensive, which would restrict the Authority's ability to do general decryption of transactions: adding a small random number would work.)
+(Note: reversing this mapping requires a brute-forcing of the discrete logarithm. This requires us
+to restrict the possible values for the inputs. This is not hard to do but, additionally, we can
+potentially use this fact to make decryption computationally intensive, which would restrict the
+Authority's ability to do general decryption of transactions: adding a small random number would
+work.)
 
-Next, choose a random non zero number, `r`, from Fq. This must be a different random number for each commitment transfer (or burn). Compute shared secrets, S1, S2, S3 where:
+Next, choose a random non zero number, `r`, from Fq. This must be a different random number for each
+commitment transfer (or burn). Compute shared secrets, S1, S2, S3 where:
 
-```
+```sh
 S1 = r.Y1
 S2 = r.Y2
 S3 = r.Y3
 ```
 
-Recall that each Y is an authority public key. Then compute the final encryption as a 4-tuple, C0, C1, C2, C3:
+Recall that each Y is an authority public key. Then compute the final encryption as a 4-tuple, C0,
+C1, C2, C3:
 
-```
+```sh
 C0 = r.G
 C1 = M1 + S1
 C2 = M2 + S2
 C3 = M3 + S3
 ```
 
-Where C1 to C3 are the result of point additions. This 4-tuple is emitted by the shield contract as part of the transaction.
+Where C1 to C3 are the result of point additions. This 4-tuple is emitted by the shield contract as
+part of the transaction.
 
 ## Decryption by Authority (knows x1, x2, x3, does not know r)
 
-Only the Authority can find the hidden values `C`, `pkA`, and `pkB`. Using `C0` and the private keys `x`, each secret `S` can be found:
+Only the Authority can find the hidden values `C`, `pkA`, and `pkB`. Using `C0` and the private keys
+`x`, each secret `S` can be found:
 
-```
+```sh
 x1.C0 = x1.(r.G) = r.(x1.G) = r.(Y1) = S1
 ```
 
 Similarly for S2 and S3. Then:
 
-```
+```sh
 M1 = C1 - S1
 M2 = C2 - S2
 M3 = C3 - S3
 ```
 
-Once the original `M`s have been found, they can be brute-forced to reveal the original values.
+Once the original `M` s have been found, they can be brute-forced to reveal the original values.

--- a/setup/gm17/rc/ft-burn.zok
+++ b/setup/gm17/rc/ft-burn.zok
@@ -37,6 +37,9 @@ import "../common/merkle-tree/pk-root" as pkroot
 
 def main(field publicInputHash, private field contractAddress, private field[2] payTo, private field value, private field[2] secretKey, private field[2] salt, private field[32] path, private field order, private field[2] nullifier, private field[2] root, private field publicKeyRoot, private field[32] pathPublicKey, private field orderPublicKey, private field[4] encryption, private field[2] authorityPublicKey1, private field randomSecret)->():
 
+	// Check the commitment values will not overflow the 128 bits
+    0 == if value < 2**128 then 0 else 1 fi
+
 	// Unpack the inputs of main()
 	field[256] publicInputHashBits = unpack256(publicInputHash)
 	field[256] payToBits = unpack2x128To256(payTo)

--- a/setup/gm17/rc/ft-mint.zok
+++ b/setup/gm17/rc/ft-mint.zok
@@ -17,6 +17,7 @@ def main(field publicInputHash, private field contractAddress, private field val
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. The unpacked binary string is in big endian format, left-padded with 0's. (NOTE: THIS METHOD OF PADDING IS DIFFERENT FROM THE PADDING REQUIRED FOR SHA256 - i.e. unpack128() padding is very different from that produced by shaPad64To512())
 	// unpack128 unpacks a field element to 128 field elements.
 	// The coin value is only 128 bits - no one will want more money than that.
+	0 == if value < 2**128 then 0 else 1 fi //...but lets check just in case
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
 	field[256] contractAddressBits = unpack256(contractAddress)

--- a/setup/gm17/rc/ft-transfer.zok
+++ b/setup/gm17/rc/ft-transfer.zok
@@ -52,6 +52,13 @@ import "../common/merkle-tree/pk-root" as pkroot
 
 def main(field publicInputHash, private field contractAddress, private field valueC, private field[2] secretKeyA, private field[2] saltC, private field[32] pathC, private field orderC, private field valueD, private field[2] saltD, private field[32] pathD, private field orderD, private field[2] nullifierC, private field[2] nullifierD, private field valueE, private field[2] publicKeyB, private field[2] saltE, private field[2] commitmentE, private field valueF, private field[2] saltF, private field[2] commitmentF, private field[2] root, private field publicKeyRoot, private field[32] pathPublicKey, private field orderPublicKey, private field[8] encryption, private field[2] authorityPublicKey1, private field[2] authorityPublicKey2, private field[2] authorityPublicKey3, private field randomSecret)->():
 
+	// Check the commitment values will not overflow the 128 bits
+
+	0 == if valueC < 2**128 then 0 else 1 fi
+	0 == if valueD < 2**128 then 0 else 1 fi
+	0 == if valueE < 2**128 then 0 else 1 fi
+	0 == if valueF < 2**128 then 0 else 1 fi
+
 	// Unpack the inputs of main() to 128 bits. We'll unpack each field to its own 128 bit string for simplicity for now. Later efficiencies could be made by grouping some inputs.
 
 	field[256] publicInputHashBits = unpack256(publicInputHash)
@@ -142,12 +149,6 @@ def main(field publicInputHash, private field contractAddress, private field val
 	sumIn == sumOut
 	encryptionCheck == encryption
 	publicKeyRoot == publicKeyRootCheck
-
-	// Overflow prevention:
-	valueCBits[0] == 0
-	valueDBits[0] == 0
-	valueEBits[0] == 0
-	valueFBits[0] == 0
 
 
 	// Check that the 'public inputs' hash to the publicInputHash:


### PR DESCRIPTION
### Related Ticket

Closes #49 

#### Dependent PR's

Fixes vulnerability as in Nightlite PR #45 

### Description

Fixes possibility of a user overflowing the value field of a commitment by inputting a value such that, when truncated to 128 bits, the checks pass. Discovered by @iAmMichaelConnor.

We check for overflow before unpacking in each fungible .zok file.

### Checklist

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x] I have made all necessary changes to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
