### PR TITLE
fix: commitment indexes converting to hex in kyc

### DIFF
--- a/Element.js
+++ b/Element.js
@@ -18,7 +18,7 @@ class Element {
     if (hex === '') throw new Error('input was empty');
     if (encoding === undefined) throw new Error('An encoding must be specified');
     // eslint-disable-next-line valid-typeof
-    this.hex = typeof hex === 'bigint' ? hex : utils.ensure0x(hex);
+    this.hex = typeof hex === 'bigint' ? hex : utils.ensure0x(hex.toString(16));
     this.encoding = encoding;
     if (encoding === 'field') {
       this.packingSize = packingSize || config.ZOKRATES_PACKING_SIZE;

--- a/el-gamal.md
+++ b/el-gamal.md
@@ -6,9 +6,7 @@ public key (or keys). It may be enforced by requiring a user to prove in zero kn
 have correctly encrypted transaction data (specifically: the value sent, `value`; the public key of
 the sender `pkA`; the public key of the recipient, `pkB`).
 
-
 El-Gamal encryption over a Baby Jubjub elliptic curve is a snark-friendly way to do the encryption.
-
 
 ## Setup
 
@@ -24,13 +22,11 @@ The point `G` is a publicly known generator of the Baby Jubjub curve. The dot pr
 curve. A good explanation of arithmetic over this particular curve can be found
 [here](https://iden3-docs.readthedocs.io/en/latest/iden3_repos/research/publications/zkproof-standards-workshop-2/baby-jubjub/baby-jubjub.html).
 
-
 ## Encryption by a user (don't know x1, x2, x3)
 
 A regular user of this scheme must encrypt and send the commitment value (`value`), their zkp public
 key (`pkA`), and the recipient's zkp public key (`pkB`) such that only the authority can decrypt
 them.
-
 
 El-Gamal encryption works on curve points, so the values to be encrypted need to be mapped using
 scalar multiplication:


### PR DESCRIPTION
### Description

Fix for the kyc branch where indexes were being converted from decimal to hex via the element class before being passed to the proof. Only affected indexes > 15, so only the batch test fails.

Now the element class converts a non-bigint input to a hex string before converting it to a field type.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x] I have made all necessary changes to the documentation.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
