### PR TITLE
consolidation transfer commitment issue fix while generating commitment index

### DIFF
--- a/erc20.js
+++ b/erc20.js
@@ -741,7 +741,7 @@ async function consolidationTransfer(
   // check we have arrays of the correct length
   if (inputCommitments.length !== config.BATCH_PROOF_SIZE)
     // keep this for now - TODO add CONSOL_PROOF_SIZE
-    throw new Error('outputCommitments array is the wrong length');
+    throw new Error('inputCommitments array is having wrong length');
 
   // as BigInt is a better representation (up until now we've preferred hex strings), we may get inputs passed as hex strings so let's do a conversion just in case
   // addition check
@@ -856,7 +856,7 @@ async function consolidationTransfer(
   const newLeafLog = txReceipt.logs.filter(log => {
     return log.event === 'NewLeaf';
   });
-  outputCommitment.commitmentIndex = parseInt(newLeafLog[0].args.LeafIndex, 10);
+  outputCommitment.commitmentIndex = parseInt(newLeafLog[0].args.leafIndex, 10);
 
   logger.debug('CONSOLIDATION TRANSFER COMPLETE\n');
 


### PR DESCRIPTION
### Description

This PR is having a fix to generate the commitment index in erc20.js file while an API calls the respective function for consolidation transfer.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
