### PR TITLE
Bug fix: Element.js not referring to local config.js for packing size

### DIFF
--- a/Element.js
+++ b/Element.js
@@ -1,4 +1,4 @@
-const config = require('config');
+const config = require('./config');
 const utils = require('./utils');
 
 /**


### PR DESCRIPTION
### Description

Changes config Element.js file is referring to - now it looks for config.js in Nightlite, not an external one which may not specify packing size for Zokrates inputs. 

### Testing

Tested with Nightfall, removing all references to packing size. Element.js correctly looks in Nightlite/config.js.

### Checklist

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
