### PR TITLE
remove usage of account in merkleTree.getSiblingPath function

### DIFF
--- a/erc20.js
+++ b/erc20.js
@@ -247,13 +247,11 @@ async function transfer(
 
   // Get the sibling-path from the token commitments (leaves) to the root. Express each node as an Element class.
   inputCommitments[0].siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     inputCommitments[0].commitment,
     inputCommitments[0].commitmentIndex,
   );
   inputCommitments[1].siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     inputCommitments[1].commitment,
     inputCommitments[1].commitmentIndex,
@@ -578,7 +576,6 @@ async function simpleFungibleBatchTransfer(
 
   // Get the sibling-path from the token commitments (leaves) to the root. Express each node as an Element class.
   inputCommitment.siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     inputCommitment.commitment,
     inputCommitment.commitmentIndex,
@@ -766,7 +763,6 @@ async function consolidationTransfer(
   const inputPaths = [];
   for (let i = 0; i < inputCommitments.length; i += 1) {
     inputCommitments[i].siblingPath = await merkleTree.getSiblingPath(
-      account,
       fTokenShieldInstance,
       inputCommitments[i].commitment,
       inputCommitments[i].commitmentIndex,
@@ -924,7 +920,6 @@ async function burn(
 
   // Get the sibling-path from the token commitments (leaves) to the root. Express each node as an Element class.
   const siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     commitment,
     commitmentIndex,

--- a/erc20rc.js
+++ b/erc20rc.js
@@ -395,13 +395,11 @@ async function transfer(
 
   // Get the sibling-path from the token commitments (leaves) to the root. Express each node as an Element class.
   inputCommitments[0].siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     inputCommitments[0].commitment,
     inputCommitments[0].commitmentIndex,
   );
   inputCommitments[1].siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     inputCommitments[1].commitment,
     inputCommitments[1].commitmentIndex,
@@ -749,7 +747,6 @@ async function burn(
 
   // Get the sibling-path from the token commitments (leaves) to the root. Express each node as an Element class.
   const siblingPath = await merkleTree.getSiblingPath(
-    account,
     fTokenShieldInstance,
     commitment,
     commitmentIndex,

--- a/erc721.js
+++ b/erc721.js
@@ -223,7 +223,6 @@ async function transfer(
 
   // Get the sibling-path from the token commitment (leaf) to the root. Express each node as an Element class.
   const siblingPath = await merkleTree.getSiblingPath(
-    account,
     nfTokenShieldInstance,
     commitment,
     commitmentIndex,
@@ -418,7 +417,6 @@ async function burn(
 
   // Get the sibling-path from the token commitment (leaf) to the root. Express each node as an Element class.
   const siblingPath = await merkleTree.getSiblingPath(
-    account,
     nfTokenShieldInstance,
     commitment,
     commitmentIndex,

--- a/merkleTree/index.js
+++ b/merkleTree/index.js
@@ -195,14 +195,13 @@ This function computes the path through a Mekle tree to get from a token
 to the root by successive hashing.  This is needed for part of the private input
 to proofs that need demonstrate that a token is in a Merkle tree.
 It works for any size of Merkle tree, it just needs to know the tree depth, which it gets from config.js
-@param {string} account - the account that is paying for these tranactions
 @param {contract} shieldContract - an instance of the shield contract that holds the commitments
 @param {string} commitment - the commitment value
 @param {integer} commitmentIndex - the leafIndex within the shield contract's merkle tree of the commitment we're getting the sibling path for
 @returns {object} containing: an array of strings - where each element of the array is a node of the sister-path of
 the path from myToken to the Merkle Root and whether the sister node is to the left or the right (this is needed because the order of hashing matters)
 */
-async function getSiblingPath(account, shieldContract, _commitment, commitmentIndex) {
+async function getSiblingPath(shieldContract, _commitment, commitmentIndex) {
   // check the commitment's format:
   // logger.debug('commitment', commitment);
   // if (commitment.length !== config.LEAF_HASHLENGTH * 2) {
@@ -233,7 +232,7 @@ async function getSiblingPath(account, shieldContract, _commitment, commitmentIn
   logger.debug('\nChecking root...');
   const rootInDb = siblingPath[0];
   logger.debug('rootInDb:', rootInDb);
-  const rootOnChain = await shieldContract.roots.call(rootInDb, { from: account });
+  const rootOnChain = await shieldContract.roots.call(rootInDb);
   logger.debug('rootOnChain:', rootOnChain);
   if (rootOnChain !== rootInDb)
     throw new Error(


### PR DESCRIPTION

### Description
PR do a small refactor in code - update a `getSiblingPath` function to not pass anonymous generated account to make get `roots` call 

### QA Instructions

<!-- How others should test your changes and check for any possible regressions. -->

- [ ] Step 1

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
