### PR TITLE
feat: supplement with some property tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "cod-scripts": "^3.3.0",
     "ethlint": "^1.2.4",
+    "fast-check": "^1.26.0",
     "markdownlint-cli": "^0.18.0",
     "nodemon": "^1.19.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.31",


### PR DESCRIPTION
## Description

Supplement existing tests with some property tests. Property tests will improve the robustness of the codebase by testing functions against a wider input space and reduce the reliance of set-once unit test vectors such as `TEST_PRIVATE_KEYS` which may not be representative of the potential input space.

The premise is the following:
1. Define a property or invariance that a function should conform to.
2. Generate a set of random (but well-defined) input values.
3. Test to see that the property holds.

I've used [fast-check](https://github.com/dubzzz/fast-check) which is somewhat based on the Quickcheck, the canonical property testing tool. It also provides useful shrinking functionality so that the smallest failing test can be produced for inspection.

This does increase the running time for tests (based on the currently set number of runs per time) but can be tweaked for performance. However, we save about 50% of the time to run the `Edwards compression tests` as we can do without cryptographically secure random scalars in that test.

### QA Instructions

- [x] `npm test`

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
