### PR TITLE
fix: point decompression of netural element

### DIFF
--- a/elgamal.js
+++ b/elgamal.js
@@ -190,6 +190,7 @@ function edwardsDecompress(y) {
     addMod([mulMod([JUBJUBD, y2]), -JUBJUBA]),
     ZOKRATES_PRIME,
   );
+  if (x2 === 0n && sign === '0') return BABYJUBJUB.INFINITY;
   let xfield = squareRootModPrime(x2);
   const px = BigInt(xfield)
     .toString(2)


### PR DESCRIPTION
### Description

Point compression of the neutral element is correct. However, as part of the testing in #71, an unhandled error is thrown from `edwardsDecompress` if the we try to recover the neutral element `(0,1)`. 

![image](https://user-images.githubusercontent.com/9293647/90331464-18848980-dfe7-11ea-9f9b-76c941895ac0.png)

This is because `x2` in the `edwardsDecompress` has a value of 0 for the neutral element which causes `squareRootModPrime` to return `NaN`.

AFAIK point (de)compression is defined for all points on a Twisted Edwards Curve so the simple solution is to check if `x2` is zero and the parity, `sign`, is even. If so we return`BABYJUBJUB.INFINITY`

### QA Instructions

<!-- How others should test your changes and check for any possible regressions. -->
In `master` currently
- [x] `edwardsDecompress(edwardsCompress(scalarMult(BigInt('0'), BABYJUBJUB.GENERATOR)))`
- [x] Observe error 
```
Thrown:
RangeError: The number NaN cannot be converted to a BigInt because it is not an integer
    at BigInt (<anonymous>)
    at edwardsDecompress ([eval]:194:14)
```
With this PR:
- [x] `edwardsDecompress(edwardsCompress(scalarMult(BigInt('0'), BABYJUBJUB.GENERATOR)))`
- [x] Returns `[ 0n, 1n ]`

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
