### PR TITLE
fix: base config conditional NODE_HASHLENGTH

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   LEAF_HASHLENGTH: 32, // expected length of an input to a hash in bytes
-  NODE_HASHLENGTH: 27,
+  NODE_HASHLENGTH: process.env.HASH_TYPE === 'mimc' ? 32 : 27,
   HASH_TYPE: process.env.HASH_TYPE,
   BATCH_PROOF_SIZE: 20, // the number of proofs in a batch (you will need to redo the proofs if oyu change this)
   ZOKRATES_PACKING_SIZE: 128, // ZOKRATES_PRIME is approx 253-254bits (just shy of 256), so we pack field elements into blocks of 128 bits.


### PR DESCRIPTION
### Description

NODE_HASHLENGTH: 27 was causing merkleTree.checkRoot to fail calculating the same root as tinder when HAS_TYPE:'mimc' due to tinder having NODE_HASHLENGTH: 32


### QA Instructions
- [ ] Try to run a Transfer with HASH_TYPE:'mimc' in tinder and the api,
- [ ] checkRoot gets NODE_HASHLENGTH: 32 and works properly

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
