### PR TITLE
feat: enable tx signing with external callback method

### DIFF
--- a/contractUtils.js
+++ b/contractUtils.js
@@ -2,7 +2,7 @@ const contract = require('truffle-contract');
 const jsonfile = require('jsonfile');
 const Web3 = require('./provider');
 
-const web3 = Web3.connect();
+let web3 = Web3.connect();
 
 const contractMapping = {
   NFTokenShield: `${process.cwd()}/build/contracts/NFTokenShield.json`,
@@ -17,6 +17,7 @@ const contractMapping = {
  * @param {String} contractAddress [optional] address of contract
  */
 function getTruffleContractInstance(contractName, contractAddress) {
+  web3 = Web3.connect();
   if (!contractMapping[contractName]) {
     throw new Error('Unknown contract type in getTruffleContractInstance');
   }
@@ -30,6 +31,27 @@ function getTruffleContractInstance(contractName, contractAddress) {
   return contractInstance.deployed();
 }
 
+/**
+ * get contract instance
+ * @param {String} contractNam:e contract name
+ * @param {String} contractAddress: address of contract
+ */
+function getWeb3ContractInstance(contractName, contractAddress) {
+  web3 = Web3.connection();
+  if (!contractMapping[contractName]) {
+    throw new Error('Unknown contract type in getWeb3ContractInstance');
+  }
+  const contractJson = jsonfile.readFileSync(contractMapping[contractName]);
+  return new web3.eth.Contract(contractJson.abi, contractAddress);
+}
+
+function sendSignedTransaction(signedTransaction) {
+  web3 = Web3.connection();
+  return web3.eth.sendSignedTransaction(signedTransaction);
+}
+
 module.exports = {
   getTruffleContractInstance,
+  getWeb3ContractInstance,
+  sendSignedTransaction,
 };


### PR DESCRIPTION
### Related Ticket

https://eyblockchain.atlassian.net/browse/TAX-1228

### Description

- Enable tx signing in `erc20.js` and `erc721.js` files
   - The approach is to expect a callback `signingMethod` for `mint`/`transfer`/`burn` methods
   - Truffle contract documentation does not provide proper information on how to get raw transactions for signing so the changes involve switching from truffle contract instance to web3 contract instance at the moment of signing
   - To enable privacy in transfers, an extra param is sent to the signingMethod with `true` to let the method know that for this particular tx, a new account needs to be created. This was tested using the branch from this PR in authentication-api: https://github.com/EYBlockchain/authentication-api/pull/134

### QA Instructions

- [ ] Copy nightlte code directly in their `/src` folder and change all the nightlite imports from `@eyblockchain/nightlite` to its local nightlite folder
- [ ] For all the methods used (`<erc20|erc721>.<mint|transfer|burn>`) send a callback function that can sign the tx
- [ ] Check results

### Checklist

- [X] I have reviewed the code changes myself
- [X] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
